### PR TITLE
Move JS and Sass to generic resolver, fix settings

### DIFF
--- a/hyper_click.sublime-settings
+++ b/hyper_click.sublime-settings
@@ -5,7 +5,7 @@
     "annotations_enabled": true,
 
     // HyperClick is enabled when the current scope matches this selector
-    "selector": "source.js,source.sass,source.scss,source.less,embedding.php,source.stylus,text.html,source.jstl,source.css,source.pug,source.sugarss,text.sugarml,source.nunjucks,source.jinja2,text.html.twig,source.dart,text.html.smarty",
+    "selector": "source.js,source.ts,source.sass,source.scss,source.less,embedding.php,source.stylus,text.html,source.jstl,source.css,text.pug,source.sugarss,text.sugarml,source.nunjucks,source.jinja2,text.html.twig,source.dart,text.html.smarty",
 
     // Supported languages
     // - each has at least a regex to match import statements
@@ -23,13 +23,34 @@
             ],
             "extensions": ["js", "jsx", "vue", "mjs", "ts", "tsx", "svelte"],
             "vendor_dirs": ["node_modules"],
+            "lookup_paths": [],
+            "aliases": {}
+        },
+        "source.ts": {
+            "regexes": [
+                "^import\\s+['\"](.+)['\"];?$",
+                ".*from\\s+['\"](.+)['\"];?$",
+                ".*require\\(['\"](.+?)['\"]\\).*",
+                ".*import\\((?:\\/\\*.+?\\*\\/\\s+)?['\"](.+)['\"]\\)(?:[;\\.,])?",
+            ],
+            "extensions": ["js", "jsx", "vue", "mjs", "ts", "tsx", "svelte"],
+            "vendor_dirs": ["node_modules"],
+            "lookup_paths": [],
             "aliases": {}
         },
         "source.sass": {
             "regexes": [
                 "^@import\\s+['\"](.+)['\"];?$"
             ],
-            "extensions": ["scss", "sass"]
+            "extensions": ["sass"],
+            "vendor_dirs": ["node_modules"]
+        },
+        "source.scss": {
+            "regexes": [
+                "^@import\\s+['\"](.+)['\"];?$"
+            ],
+            "extensions": ["scss"],
+            "vendor_dirs": ["node_modules"]
         },
         "source.less": {
             "regexes": [
@@ -57,7 +78,7 @@
                 ".*?<link\\s+rel=\"import\"\\s+href=['\"](.+)['\"]/?>.*?"
             ],
             "extensions": ["html"],
-            "vendor_dirs": ["node_modules", "bower_components"]
+            "vendor_dirs": ["node_modules"]
         },
         "text.html.jstl": {
             "regexes": [
@@ -75,7 +96,7 @@
                 "^@import\\s+['\"](.+)['\"].*?;$",
                 "^@import\\s+url\\(['\"](.+)['\"]\\).*?;$"
             ],
-            "extensions": ["css", "pcss", "postcss"]
+            "extensions": ["css", "pcss"]
         },
         "text.pug": {
             "regexes": [

--- a/hyper_click/generic_path_resolver.py
+++ b/hyper_click/generic_path_resolver.py
@@ -1,5 +1,26 @@
 import sublime
 from os import path
+import json
+
+NODE_CORE_MODULES = { 'assert', 'async_hooks', 'buffer', 'child_process', 'cluster', 'console', 'constants', 'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'http2', 'https', 'module', 'net', 'os', 'path', 'perf_hooks', 'process', 'punycode', 'querystring', 'readline', 'repl', 'stream', 'string_decoder', 'sys', 'timers', 'tls', 'trace_events', 'tty', 'url', 'util', 'v8', 'vm', 'wasi', 'worker_threads', 'zlib', 'assert/strict', 'dns/promises', 'fs/promises', 'stream/promises', 'timers/promises' }
+
+NODE_CORE_MODULES_TEMPLATE = "https://github.com/nodejs/node/blob/master/lib/{}.js"
+
+def walkup_dir(start_path, vendor_dirs, endpath = '/'):
+    current_dir = start_path
+    target = current_dir
+    while True:
+        for dirname in vendor_dirs:
+            target = path.join(current_dir, dirname)
+            if path.isdir(target):
+                yield target
+            if current_dir == endpath:
+                return
+            # go up
+            parent_dir = path.dirname(current_dir)
+            if len(parent_dir) == len(current_dir):
+                return
+            current_dir = parent_dir
 
 
 # A default resolver that resolves to a subfolder along along with one of the valid extensions
@@ -7,27 +28,36 @@ class GenericPathResolver:
     def __init__(self, view, str_path, current_dir, roots, settings):
         self.str_path = str_path
         self.current_dir = current_dir
-        self.aliases = []
+        self.aliases = {}
         self.valid_extensions = []
+        self.vendor_dirs = []
         self.lookup_paths = []
+
+        cursor = view.sel()[0].a
+        self.scope_is_js = view.match_selector(cursor, 'source.js,source.ts')
+        self.scope_is_sass = view.match_selector(cursor, 'source.scss,source.sass')
 
         matching_roots = [root for root in roots if self.current_dir.startswith(root)]
         self.current_root = matching_roots[0] if matching_roots else self.current_dir
 
         scopes = settings.get('scopes', {})
         for selector in scopes:
-            if view.match_selector(view.sel()[0].a, selector):
-                self.aliases = scopes[selector].get('aliases', [])
+            if view.match_selector(cursor, selector):
+                self.aliases = scopes[selector].get('aliases', {})
                 self.valid_extensions = scopes[selector].get('extensions', [])
-                self.lookup_paths = scopes[selector].get('lookup_paths', [])
+                self.vendor_dirs = scopes[selector].get('vendor_dirs', [])
+                self.lookup_paths = scopes[selector].get('vendor_dirs', [])
+                self.lookup_paths.extend(
+                    scopes[selector].get('lookup_paths', [])
+                )
 
         # check the view for applicable project settings
         project_settings = view.settings().get('hyper_click', {})
         project_scopes = project_settings.get('scopes', {})
         for selector in project_scopes:
-            if view.match_selector(view.sel()[0].a, selector):
-                self.aliases.extend(
-                    project_scopes[selector].get('aliases', [])
+            if view.match_selector(cursor, selector):
+                self.aliases.update(
+                    project_scopes[selector].get('aliases', {})
                 )
                 self.valid_extensions.extend(
                     project_scopes[selector].get('extensions', [])
@@ -37,12 +67,19 @@ class GenericPathResolver:
                 )
 
     def resolve(self):
+        if self.scope_is_js:
+            # Core modules
+            if self.str_path in NODE_CORE_MODULES:
+                return NODE_CORE_MODULES_TEMPLATE.format(self.str_path)
+
         combined = path.realpath(path.join(self.current_dir, self.str_path))
 
-        # Try to match the literal filename referenced
-        # match: '../variables/palette.less'
-        if path.isfile(combined):
-            return combined
+        # match: '../variables/palette' -> '../variables/palette.less'
+        # match: '../variables/palette' -> '../variables/_palette.scss'
+        result = self.resolve_as_file(combined)
+        if result:
+            return result
+
 
         # Try to use the path given in project settings for this language
         result = self.resolve_in_lookup_paths(self.str_path)
@@ -51,16 +88,24 @@ class GenericPathResolver:
 
         # Resolve by alias
         # match 'Styles/variables/palette' to 'src/less/variables/palette.less'
-        # for alias, alias_source in self.aliases.items():
-        #     result = self.resolve_from_alias(alias, alias_source)
-        #     if result:
-        #         return result
+        for alias, alias_source in self.aliases.items():
+            result = self.resolve_from_alias(alias, alias_source)
+            if result:
+                return result
+
+        if self.scope_is_js:
+            result = self.resolve_node_modules(self.str_path, self.current_dir)
+            if result:
+                return result
 
         return ''
 
     def resolve_relative_to_dir(self, target, directory):
         combined = path.realpath(path.join(directory, target))
-        return self.resolve_as_file(combined)
+        if self.scope_is_js:
+            return self.resolve_as_file(combined) or self.resolve_as_directory(combined)
+        else:
+            return self.resolve_as_file(combined)
 
     def resolve_in_lookup_paths(self, target):
         for lookup_path in self.lookup_paths:
@@ -76,12 +121,63 @@ class GenericPathResolver:
 
             return self.resolve_relative_to_dir(path.join(*path_parts), self.current_root)
 
-    def resolve_as_file(self, path_name):
-        if path.isfile(path_name):
-            return path_name
-
+    def resolve_with_exts(self, path_name):
         # matching ../index to /index.js
         for ext in self.valid_extensions:
             file_path = path_name + '.' + ext
             if path.isfile(file_path):
                 return file_path
+
+    def resolve_as_file(self, path_name):
+        if path.isfile(path_name):
+            return path_name
+
+        with_ext = self.resolve_with_exts(path_name)
+        if with_ext:
+            return with_ext
+
+        # "A partial is a Sass file named with a leading underscore [that] should not be generated into a CSS file" - https://sass-lang.com/guide
+        if self.scope_is_sass:
+            underscore_extd = self.resolve_with_underscore(path_name)
+            if underscore_extd:
+                return underscore_extd
+
+    def resolve_with_underscore(self, path_name):        
+        pathname, filename = path.split(path_name)
+        combined = path.join(pathname, '_' + filename)
+
+        if path.isfile(combined):
+            return combined
+
+        return self.resolve_with_exts(combined)
+
+    def resolve_node_modules(self, target, start_dir):
+        for vendor_path in walkup_dir(start_dir, self.vendor_dirs, self.current_root):
+            lookup_path = path.join(vendor_path, target)
+            result = self.resolve_as_file(lookup_path)
+            if result:
+                return result
+            result = self.resolve_as_directory(lookup_path)
+            if result:
+                return result
+
+    def resolve_index(self, dirname):
+        # matching ./demo to /demo/index.js
+        if path.isdir(dirname):
+            return self.resolve_as_file(path.join(dirname, 'index.js'))
+
+    def resolve_as_directory(self, dirname):
+        package_json_path = path.join(dirname, 'package.json')
+        if path.isdir(dirname) and path.isfile(package_json_path):
+            with open(package_json_path, 'r', encoding='utf-8') as data_file:
+                data = json.load(data_file)
+            main_file = data.get('main', None)
+            if main_file:
+                dest = path.realpath(path.join(dirname, data['main']))
+                result = self.resolve_nodepath(dest)
+                if result:
+                    return result
+        return self.resolve_index(dirname)
+
+    def resolve_nodepath(self, nodepath):
+        return self.resolve_as_file(nodepath) or self.resolve_index(nodepath)

--- a/hyper_click/jstl_path_resolver.py
+++ b/hyper_click/jstl_path_resolver.py
@@ -1,26 +1,28 @@
-# -*- coding: utf-8 -*-
 import re
 from os import path
 
+dirs_regex = [
+    "taglib *prefix ?= ?[\"'](.*)[\"'] *tagdir ?= ?[\"'](.*)[\"']",
+    "xmlns:(\\w*)=[\"']urn:jsptagdir:(.*?)[\"']"
+]
+prog = re.compile('(<([\\w-]*)\\:([\\w-]*))')
 
+# TEMP: hardcoded settings
 class JstlPathResolver:
-    def __init__(self, view, str_lookup, current_dir, roots, lang, settings):
+    def __init__(self, view, str_lookup, current_dir, roots, settings):
         self.view = view
-        self.import_line_regex = settings.get('import_line_regex', {})[lang]
-        prog = re.compile(self.import_line_regex[0])
         regMatch = prog.match(str_lookup)
         self.str_path = regMatch.group(2)
         self.str_file = regMatch.group(3)
         self.current_dir = current_dir
-        self.lang = lang
         self.settings = settings
         self.roots = roots
-        self.valid_extensions = settings.get('valid_extensions', {})[lang]
-        self.dirs_regex = settings.get('lookup_paths', {})[lang]
-        self.vendors = settings.get('vendor_dirs', {})[lang]
+
+        self.valid_extensions = ['jsp', 'tag']
+        self.vendors = ['WEB-INF']
 
     def resolve(self):
-        for regex_str in self.dirs_regex:
+        for regex_str in dirs_regex:
             regions = self.view.find_all(regex_str)
             for region in regions:
                 file_path = self.find_folder(region)
@@ -43,7 +45,7 @@ class JstlPathResolver:
         return ''
 
     def is_valid_line(self, line_content):
-        for regex_str in self.dirs_regex:
+        for regex_str in dirs_regex:
             pattern = re.compile(regex_str)
             matched = pattern.match(line_content)
             if matched:

--- a/hyper_click/path_resolver.py
+++ b/hyper_click/path_resolver.py
@@ -1,6 +1,4 @@
 from os import path
-from .js_path_resolver import JsPathResolver
-from .sass_path_resolver import SassPathResolver
 from .jstl_path_resolver import JstlPathResolver
 from .generic_path_resolver import GenericPathResolver
 
@@ -9,14 +7,11 @@ class HyperClickPathResolver:
     def __init__(self, view, str_path, roots, settings):
         current_file = view.file_name()
         current_dir = path.dirname(path.realpath(current_file))
-        # if scope == 'source.js':
-        #     self.resolver = JsPathResolver(view, str_path, current_dir, roots, settings, proj_settings)
-        # elif scope == 'source.sass':
-        #     self.resolver = SassPathResolver(view, str_path, current_dir, roots, settings, proj_settings)
-        # elif scope == 'source.jstl':
-        #     self.resolver = JstlPathResolver(view, str_path, current_dir, roots, settings)
-        # else:
-        self.resolver = GenericPathResolver(view, str_path, current_dir, roots, settings)
+
+        if view.match_selector(view.sel()[0].a, 'text.html.jstl'):
+            self.resolver = JstlPathResolver(view, str_path, current_dir, roots, settings)
+        else:
+            self.resolver = GenericPathResolver(view, str_path, current_dir, roots, settings)
 
     def resolve(self):
         return self.resolver.resolve()

--- a/hyper_click_annotator.py
+++ b/hyper_click_annotator.py
@@ -14,12 +14,12 @@ def is_applicable(scope, view):
     if not scope:
         return False
 
-    settins = sublime.load_settings('hyper_click.sublime-settings')
-    annotations_enabled = settins.get('annotations_enabled')
+    settings = sublime.load_settings('hyper_click.sublime-settings')
+    annotations_enabled = settings.get('annotations_enabled')
     if not annotations_enabled:
         return False
 
-    selector = settins.get('selector')
+    selector = settings.get('selector')
     if view.match_selector(view.sel()[0].a, selector):
         return True
 
@@ -55,9 +55,6 @@ class HyperClickAnnotator(sublime_plugin.EventListener):
         self.syntax = view.settings().get('syntax')
         settings = sublime.load_settings('hyper_click.sublime-settings')
 
-        # Per-project settings are optional
-        self.proj_settings = view.settings().get('hyper_click', {})
-
         line_range = view.line(point)
 
         if view.line(line_range.b) == self.current_line:
@@ -74,8 +71,7 @@ class HyperClickAnnotator(sublime_plugin.EventListener):
                 view,
                 destination_str,
                 self.roots,
-                settings,
-                self.proj_settings
+                settings
             )
             region = sublime.Region(line_range.b, line_range.b)
             self.current_line = view.line(line_range.b)

--- a/hyper_click_command.py
+++ b/hyper_click_command.py
@@ -27,24 +27,22 @@ class HyperClickJumpCommand(sublime_plugin.TextCommand):
 
     def run(self, edit, event=None):
         self.window = self.view.window()
-        v = self.view
+        view = self.view
 
-        if len(v.sel()) != 1:
+        if len(view.sel()) != 1:
             return
 
         # Setting self.roots here (instead of in `__init__`) fixes a bug with files opened through the quick panel
         self.roots = self.window and self.window.folders()
-        # Per-project settings are optional
-        self.proj_settings = self.view.settings().get('hyper_click', {})
 
-        cursor = get_cursor(v, event).a
-        line_range = v.line(cursor)
-        line_content = v.substr(line_range).strip()
+        cursor = get_cursor(view, event).a
+        line_range = view.line(cursor)
+        line_content = view.substr(line_range).strip()
         matched = self.is_valid_line(line_content)
         if matched:
             destination_str = matched.group(1)
             file_path = HyperClickPathResolver(
-                v,
+                view,
                 destination_str,
                 self.roots,
                 self.settings


### PR DESCRIPTION
- removed stray references to proj_settings
- mirrored js settings for the source.ts scope
- replaced the core node modules util with a dict lookup
- the jstl resolver has different semantics
- added underscore-prefixed partials (for Sass)